### PR TITLE
feat: wgo-3903 grid improvement

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridCellsPresenter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridCellsPresenter.cs
@@ -88,7 +88,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
                 Debug.Assert(cell.OwningColumn == lastColumn, "Expected column owner.");
                 Debug.Assert(lastColumn.IsVisible, "Expected visible column.");
 
-                cell.Arrange(new Rect(gridWidth - lastColumnWidth, 0, lastColumn.LayoutRoundedWidth, finalSize.Height));
+                 cell.Background = new SolidColorBrush(Windows.UI.Colors.White);
++                cell.Arrange(new Rect(gridWidth - lastColumnWidth, 0, lastColumn.LayoutRoundedWidth + 2, finalSize.Height));
                 lastColumn.IsInitialDesiredWidthDetermined = true;
             }
 
@@ -118,7 +119,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
                 if (cell.Visibility == Visibility.Visible)
                 {
                     cell.Arrange(new Rect(cellLeftEdge, 0, column.LayoutRoundedWidth, finalSize.Height));
-                    EnsureCellClipNew(cell, column.ActualWidth, finalSize.Height, frozenLeftEdge, scrollingLeftEdge, gridWidth - lastColumnWidth);
+                    EnsureCellClipNew(cell, column.ActualWidth, finalSize.Height, frozenLeftEdge, scrollingLeftEdge, gridWidth - lastColumnWidth, isRightFrozenColumnEnabled);
                 }
 
                 scrollingLeftEdge += column.ActualWidth;
@@ -150,7 +151,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
             }
         }
 
-        private static void EnsureCellClipNew(DataGridCell cell, double width, double height, double frozenLeftEdge, double cellLeftEdge, double frozenRightEdge)
+        private static void EnsureCellClipNew(DataGridCell cell, double width, double height, double frozenLeftEdge, double cellLeftEdge, double frozenRightEdge, bool hasRightFrozenColumn)
         {
             // Clip the cell only if it's scrolled under frozen columns.  Unfortunately, we need to clip in this case
             // because cells could be transparent
@@ -166,7 +167,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
                 cell.Clip = null;
             }
 
-            if (!cell.OwningColumn.IsFrozen && cellLeftEdge + width > frozenRightEdge)
+            if (hasRightFrozenColumn && !cell.OwningColumn.IsFrozen && cellLeftEdge + width - frozenLeftEdge> frozenRightEdge)
             {
                 RectangleGeometry rg = new RectangleGeometry();
                 double xClip = cellLeftEdge + width - frozenRightEdge;

--- a/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumnHeadersPresenter.cs
+++ b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridColumnHeadersPresenter.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
                 else
                 {
                     columnHeader.Arrange(new Rect(scrollingLeftEdge, 0, dataGridColumn.LayoutRoundedWidth, finalSize.Height));
-                    EnsureColumnHeaderClipNew(columnHeader, dataGridColumn.ActualWidth, finalSize.Height, frozenLeftEdge, scrollingLeftEdge, gridWidth - lastColumnWidth);
+                    EnsureColumnHeaderClipNew(columnHeader, dataGridColumn.ActualWidth, finalSize.Height, frozenLeftEdge, scrollingLeftEdge, gridWidth - lastColumnWidth, isRightFrozenColumnEnabled);
                     if (this.DragColumn == dataGridColumn && this.DragIndicator != null)
                     {
                         dragIndicatorLeftEdge = scrollingLeftEdge + this.DragIndicatorOffset;
@@ -243,7 +243,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
             }
         }
 
-        private static void EnsureColumnHeaderClipNew(DataGridColumnHeader columnHeader, double width, double height, double frozenLeftEdge, double columnHeaderLeftEdge, double frozenRightEdge)
+        private static void EnsureColumnHeaderClipNew(DataGridColumnHeader columnHeader, double width, double height, double frozenLeftEdge, double columnHeaderLeftEdge, double frozenRightEdge, bool hasRightFrozenColumn)
         {
             // Clip the cell only if it's scrolled under frozen columns.  Unfortunately, we need to clip in this case
             // because cells could be transparent
@@ -259,7 +259,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Controls.Primitives
                 columnHeader.Clip = null;
             }
 
-            if (columnHeaderLeftEdge + width > frozenRightEdge)
+            if (hasRightFrozenColumn && columnHeaderLeftEdge + width - frozenLeftEdge > frozenRightEdge)
             {
                 RectangleGeometry rg = new RectangleGeometry();
                 double xClip = columnHeaderLeftEdge + width - frozenRightEdge;


### PR DESCRIPTION
## Fixes #<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged. -->

<!-- Add a brief overview here of the feature/bug & fix. -->

## PR Type
Data grid Improvement
<!-- Please uncomment one or more that apply to this PR. -->

Bugfix - Fix overlapping of text fields.
Feature - Remove maxwidth in DataGrid, user can drag the header with out any fixed width.
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?

Currently left pinned column can not be dragged more than 400px, and the text is overlapping on the left pinned column.

https://github.com/releaseops-svmx/WindowsCommunityToolkit/assets/115147840/1d2cd665-a70e-47d8-980b-689cef71b0b5

## What is the new behavior?

https://github.com/releaseops-svmx/WindowsCommunityToolkit/assets/115147840/8fa3fe0e-46f2-4988-ad95-25807de9ba3b


<!-- Describe how was this issue resolved or changed? -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [ ] Pull Request has been submitted to the documentation repository [instructions](..\contributing.md#docs). Link: <!-- docs PR link -->
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected. -->


## Other information
